### PR TITLE
Update Toyota MR2 generations: Add Wikipedia reference and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Toyota MR2
 
+This repository contains signal set configurations for the Toyota MR2, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Toyota MR2.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Toyota_MR2"
+
 generations:
   - name: "First Generation (W10)"
     start_year: 1984


### PR DESCRIPTION
- Added Wikipedia reference (https://en.wikipedia.org/wiki/Toyota_MR2) to generations.yaml
- Updated README.md with standard template documentation
- Verified all three generation dates match Wikipedia data:
  * First Generation (W10): 1984-1989
  * Second Generation (W20): 1989-1999
  * Third Generation (W30): 1999-2007
